### PR TITLE
Removes strict dep to stats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     glue (>= 1.3.0),
     knitr (>= 1.20),
     magrittr (>= 1.5),
-    stats (>= 3.5.0),
+    stats,
     stringr (>= 1.3.1),
     utils
 Suggests: 


### PR DESCRIPTION
strict dependency to `stats (>= 3.5.0)` prevents from installing this package if you don't have `R >= 3.5.0`.