### PR TITLE
new line after cat for cleaner messages

### DIFF
--- a/R/install_from_description.R
+++ b/R/install_from_description.R
@@ -37,10 +37,10 @@ install_if_missing <- function(to_be_installed, ...) {
   will_be_installed <- setdiff(to_be_installed, already_installed)
 
   if ( length(will_be_installed) == 0 ) {
-    cat("All required packages are installed")
+    cat("All required packages are installed\n")
     return(invisible(NULL))
   }
-  cat("Installation of: ", will_be_installed)
+  cat("Installation of: ", will_be_installed, "\n")
 
   install.packages(will_be_installed, ...)
 }


### PR DESCRIPTION
Currently, `attachement` is using `cat` for printing message. It requires to add new line manually to have several messages print correctly. Example: 
```r
> cat("A message");cat("another message\n");cat("a final message", sep = "\n")
A messageanother message
a final message
```

This PR add those new lines in `install_if_missing`