### PR TITLE
from_rmd Run inside session by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
         branch: master
       skip_cleanup: true
   - r: oldrel
-  - r: 3.4
 
 before_install:
   - Rscript -e 'update.packages(ask = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Depends: 
     R (>= 3.4)
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # attachment 0.1.0.9000
 
+Breaking changes
+* `att_from_rmd()` and `att_from_rmds()` are not anymore executed in separate R session by default. You must set `inside_rmd = TRUE` to do so.
+
+Minor
 * `att_to_desc_from_is()` add parameter `normalize` to avoid problem with {desc}. (See https://github.com/r-lib/desc/issues/80)
 
 # attachment 0.1

--- a/R/att_to_description.R
+++ b/R/att_to_description.R
@@ -10,6 +10,7 @@
 #'
 #' @inheritParams att_from_namespace
 #' @inheritParams att_to_desc_from_is
+#' @inheritParams att_from_rmds
 #'
 #' @return Update DESCRIPTION file.
 #' att_to_desc_from_pkg(), att_amend_desc() are aliases
@@ -32,7 +33,8 @@ att_to_description <- function(path = ".",
                                extra.suggests = NULL,
                                pkg_ignore = NULL,
                                document = TRUE,
-                               normalize = TRUE
+                               normalize = TRUE,
+                               inside_rmd = FALSE
 ) {
 
   if (path != ".") {
@@ -110,14 +112,14 @@ att_to_description <- function(path = ".",
     # Look for R scripts
     imports <- unique(c(imports, att_from_rscripts(dir.r)))
     # Look for Rmd, in case in a bookdown
-    # imports <- unique(c(imports, att_from_rmds(dir.r)))
+    # imports <- unique(c(imports, att_from_rmds(dir.r, inside_rmd = inside_rmd)))
   }
 
   # Suggests ----
   suggests <- NULL
   # Get suggests in vignettes and remove if already in imports
   if (!grepl("^$|^\\s+$$", dir.v)) {
-    vg <- att_from_rmds(dir.v)
+    vg <- att_from_rmds(dir.v, inside_rmd = inside_rmd)
     suggests <- c(suggests, vg[!vg %in% imports])
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,7 +68,7 @@ tmpdir <- tempdir()
 file.copy(system.file("dummypackage",package = "attachment"), tmpdir, recursive = TRUE)
 dummypackage <- file.path(tmpdir, "dummypackage")
 # browseURL(dummypackage)
-att_amend_desc(path = dummypackage)
+att_amend_desc(path = dummypackage, inside_rmd = TRUE)
 ```
 
 
@@ -116,13 +116,14 @@ attachment::att_to_desc_from_is(path.d = "DESCRIPTION",
 
 
 ### To list information
-Of course, you can also use {attachment} out of a package to list all package dependencies of R scripts using `att_from_rscripts` or Rmd files using `att_from_rmds`.
+Of course, you can also use {attachment} out of a package to list all package dependencies of R scripts using `att_from_rscripts()` or Rmd files using `att_from_rmds()`.  
+If you are running this inside a Rmd, you may need parameter `inside_rmd = TRUE`.  
 
 ```{r, eval=TRUE}
 dummypackage <- system.file("dummypackage", package = "attachment")
 
 att_from_rscripts(path = dummypackage)
-att_from_rmds(path = file.path(dummypackage,"vignettes"))
+att_from_rmds(path = file.path(dummypackage, "vignettes"), inside_rmd = TRUE)
 ```
 
 ## Vignette

--- a/README.md
+++ b/README.md
@@ -79,13 +79,12 @@ file.copy(system.file("dummypackage",package = "attachment"), tmpdir, recursive 
 #> [1] TRUE
 dummypackage <- file.path(tmpdir, "dummypackage")
 # browseURL(dummypackage)
-att_amend_desc(path = dummypackage)
+att_amend_desc(path = dummypackage, inside_rmd = TRUE)
 #> Updating dummypackage documentation
-#> Updating roxygen version in /tmp/RtmpJZXTJy/dummypackage/DESCRIPTION
-#> Writing NAMESPACE
+#> Updating roxygen version in /tmp/RtmpHX9c2L/dummypackage/DESCRIPTION
 #> Loading dummypackage
 #> Writing NAMESPACE
-#> Writing my_mean.Rd
+#> Writing NAMESPACE
 #> Package(s) Rcpp is(are) in category 'LinkingTo'. Check your Description file to be sure it is really what you want.
 #> [-] 1 package(s) removed: utils.
 #> [+] 2 package(s) added: stats, ggplot2.
@@ -144,15 +143,17 @@ attachment::att_to_desc_from_is(path.d = "DESCRIPTION",
 ### To list information
 
 Of course, you can also use {attachment} out of a package to list all
-package dependencies of R scripts using `att_from_rscripts` or Rmd files
-using `att_from_rmds`.
+package dependencies of R scripts using `att_from_rscripts()` or Rmd
+files using `att_from_rmds()`.  
+If you are running this inside a Rmd, you may need parameter `inside_rmd
+= TRUE`.
 
 ``` r
 dummypackage <- system.file("dummypackage", package = "attachment")
 
 att_from_rscripts(path = dummypackage)
 #> [1] "stats"        "testthat"     "dummypackage"
-att_from_rmds(path = file.path(dummypackage,"vignettes"))
+att_from_rmds(path = file.path(dummypackage, "vignettes"), inside_rmd = TRUE)
 #> [1] "knitr"     "rmarkdown" "ggplot2"
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ cache:
   - C:\RLibrary
 
 # Adapt as necessary starting from here
+before_test:
+  - cinst pandoc
+  - ps: $env:Path += ";C:\Program Files (x86)\Pandoc\"
+  - pandoc -v
 
 build_script:
   - travis-tool.sh install_deps

--- a/man/att_from_rmd.Rd
+++ b/man/att_from_rmd.Rd
@@ -8,7 +8,8 @@ att_from_rmd(
   path,
   temp_dir = tempdir(),
   warn = -1,
-  encoding = getOption("encoding")
+  encoding = getOption("encoding"),
+  inside_rmd = FALSE
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ att_from_rmd(
 
 \item{encoding}{Encoding of the input file; always assumed to be UTF-8 (i.e.,
 this argument is effectively ignored).}
+
+\item{inside_rmd}{Logical. Whether function is run inside a Rmd,
+in case this must be executed in an external R session}
 }
 \description{
 Get all dependencies from a Rmd file

--- a/man/att_from_rmds.Rd
+++ b/man/att_from_rmds.Rd
@@ -8,7 +8,8 @@ att_from_rmds(
   path = "vignettes",
   pattern = "*.[.](Rmd|rmd)$",
   recursive = TRUE,
-  warn = -1
+  warn = -1,
+  inside_rmd = FALSE
 )
 }
 \arguments{
@@ -19,6 +20,9 @@ att_from_rmds(
 \item{recursive}{logical. Should the listing recurse into directories?}
 
 \item{warn}{-1 for quiet warnings with purl, 0 to see warnings}
+
+\item{inside_rmd}{Logical. Whether function is run inside a Rmd,
+in case this must be executed in an external R session}
 }
 \value{
 Character vector of packages called with library or require.

--- a/man/att_to_description.Rd
+++ b/man/att_to_description.Rd
@@ -16,7 +16,8 @@ att_to_description(
   extra.suggests = NULL,
   pkg_ignore = NULL,
   document = TRUE,
-  normalize = TRUE
+  normalize = TRUE,
+  inside_rmd = FALSE
 )
 
 att_to_desc_from_pkg(
@@ -29,7 +30,8 @@ att_to_desc_from_pkg(
   extra.suggests = NULL,
   pkg_ignore = NULL,
   document = TRUE,
-  normalize = TRUE
+  normalize = TRUE,
+  inside_rmd = FALSE
 )
 
 att_amend_desc(
@@ -42,7 +44,8 @@ att_amend_desc(
   extra.suggests = NULL,
   pkg_ignore = NULL,
   document = TRUE,
-  normalize = TRUE
+  normalize = TRUE,
+  inside_rmd = FALSE
 )
 }
 \arguments{
@@ -65,6 +68,9 @@ att_amend_desc(
 \item{document}{Run function roxygenise of roxygen2 package}
 
 \item{normalize}{Logical. Whether to normalize the DESCRIPTION file. See \code{\link[desc]{desc_normalize}}}
+
+\item{inside_rmd}{Logical. Whether function is run inside a Rmd,
+in case this must be executed in an external R session}
 }
 \value{
 Update DESCRIPTION file.

--- a/tests/testthat/insidermd.Rmd
+++ b/tests/testthat/insidermd.Rmd
@@ -1,0 +1,22 @@
+---
+title: "A Rmd that runs the function"
+author: "Sébastien Rochette"
+date: "03/06/2020"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+### To list information
+Of course, you can also use {attachment} out of a package to list all package dependencies of R scripts using `att_from_rscripts()` or Rmd files using `att_from_rmds()`.  
+If you are running this inside a Rmd, you may need parameter `inside_rmd = TRUE`.  
+
+```{r, eval=TRUE}
+dummypackage <- system.file("dummypackage", package = "attachment")
+
+att_from_rscripts(path = dummypackage)
+att_from_rmds(path = file.path(dummypackage, "vignettes"), inside_rmd = TRUE)
+```
+

--- a/tests/testthat/test-rmd.R
+++ b/tests/testthat/test-rmd.R
@@ -1,12 +1,8 @@
 context("test-rmd.R")
 
 test_that("rmd well parsed", {
-
   res <- sort(attachment::att_from_rmds(path = "."))
-
-
   expect_equal(sort(res),
-
                sort(
                  c("find.me",
                    # "attachment",
@@ -24,8 +20,13 @@ test_that("rmd well parsed", {
                    "findme5a",
                    "findme6a"
                  )
-
                ))
+})
 
+success_file <- rmarkdown::render("insidermd.Rmd")
+test_that("test inside rmd works", {
+  expect_equal(basename(success_file), "insidermd.html")
+})
+# clean
+file.remove(success_file)
 
-  })

--- a/vignettes/fill-pkg-description.Rmd
+++ b/vignettes/fill-pkg-description.Rmd
@@ -47,6 +47,19 @@ Run `attachment::att_amend_desc()` each time before `devtools::check()`, this wi
 att_amend_desc()
 ```
 
+#### Example on a fake package
+
+If you are running this inside a Rmd like here, you may need parameter `inside_rmd = TRUE`.  
+
+```{r}
+# Copy package in a temporary directory
+tmpdir <- tempdir()
+file.copy(system.file("dummypackage",package = "attachment"), tmpdir, recursive = TRUE)
+dummypackage <- file.path(tmpdir, "dummypackage")
+# browseURL(dummypackage)
+att_amend_desc(path = dummypackage, inside_rmd = TRUE)
+```
+
 ### For bookdown
 You can use a similar approch for a {bookdown} description file using `attachment::att_to_desc_from_is()`
 
@@ -103,13 +116,13 @@ for (i in to_install) {
 
 ## Other possibilities
 
-Of course, you can also use {attachment} out of a package to list all package dependencies of R scripts using `att_from_rscripts` or Rmd files using `att_from_rmds`.
+Of course, you can also use {attachment} out of a package to list all package dependencies of R scripts using `att_from_rscripts()` or Rmd files using `att_from_rmds()`.
 
 ```{r, eval=TRUE}
 dummypackage <- system.file("dummypackage", package = "attachment")
 
 att_from_rscripts(path = file.path(dummypackage, "R"))
-att_from_rmds(path = file.path(dummypackage, "vignettes"))
+att_from_rmds(path = file.path(dummypackage, "vignettes"), inside_rmd = TRUE)
 ```
 
 


### PR DESCRIPTION
Breaking changes
* `att_from_rmd()` and `att_from_rmds()` are not anymore executed in separate R session by default. You must set `inside_rmd = TRUE` to do so.