### PR TITLE
Add pkg_ignore to create_renv()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # attachment 0.2.4.900x
 ## Major changes
 
-* add `create_renv_for_dev()` and `create_renv_for_prod()` function to create `renv.lock` file based on development project (@VincentGuyader).
+* add `create_renv_for_dev()` and `create_renv_for_prod()` function to create `renv.lock` file based on development project (@VincentGuyader and @statnmap).
 
 ## Minor changes
 

--- a/man/create_renv_for_dev.Rd
+++ b/man/create_renv_for_dev.Rd
@@ -12,6 +12,7 @@ create_renv_for_dev(
   output = "renv.lock",
   install_if_missing = TRUE,
   document = TRUE,
+  pkg_ignore = NULL,
   ...
 )
 
@@ -25,7 +26,7 @@ create_renv_for_prod(
 \arguments{
 \item{path}{Path to your current package source folder}
 
-\item{dev_pkg}{Package development toolbox you need. Use \verb{_default}
+\item{dev_pkg}{Vector of packages you need for development. Use \verb{_default}
 (with underscore before to avoid confusing with a package name), to
 use the default list. Use \code{NULL} for no extra package.
 Use \code{attachment:::extra_dev_pkg} for the list.}
@@ -38,6 +39,9 @@ Use \code{attachment:::extra_dev_pkg} for the list.}
 
 \item{document}{Logical. Whether to run \code{\link[=att_amend_desc]{att_amend_desc()}} before
 detecting packages in DESCRIPTION.}
+
+\item{pkg_ignore}{Vector of packages to ignore from being discovered in your files.
+This does not prevent them to be in "renv.lock" if they are recursive dependencies.}
 
 \item{...}{Other arguments to pass to \code{\link[renv:snapshot]{renv::snapshot()}}}
 }

--- a/tests/testthat/test-renv_create.R
+++ b/tests/testthat/test-renv_create.R
@@ -100,7 +100,7 @@ test_that("lockfile are renv files", {
 pkg_extra <- names(local_renv_extra$data()$Packages)
 pkg_blank <- names(local_renv_blank$data()$Packages)
 
-test_that("extrapackage is present thank to dev_pkg", {
+test_that("extrapackage is present thanks to dev_pkg", {
   expect_true("extrapackage" %in% pkg_extra)
   expect_false("extrapackage" %in% pkg_blank)
   # all blank are in extra
@@ -115,7 +115,7 @@ test_that("extrapackage is present thank to dev_pkg", {
 #   expect_equal_to_reference(names(pkg_blank),"my_renv_blank.test")
 # })
 
-# Test for extra and "_default" in interactive
+# Test for extra and "_default" in interactive ----
 test_that("_default works", {
   skip_if_not(interactive())
 
@@ -143,7 +143,7 @@ test_that("_default works", {
   expect_true(all(c("devtools", "fusen") %in% pkg_extra_default))
 })
 
-# Test for "folder_to_include" in dummypackage
+# Test for "folder_to_include" in dummypackage ----
 dir.create(file.path(dummypackage, "dev"))
 cat("library(glue)", file = file.path(dummypackage, "dev", "my_r.R"))
 cat("```{r}\nlibrary(\"extrapackage\")\n```", file = file.path(dummypackage, "dev", "my_rmd.Rmd"))
@@ -157,7 +157,7 @@ test_that("folder_to_include works", {
       install_if_missing = FALSE,
       output = lock_includes_devdir,
       force = TRUE)}
-    # "There is no directory named: dev, data-raw" # cli
+    # "There is no directory named: data-raw" # cli
   )
 
   expect_true(file.exists(lock_includes_devdir))
@@ -169,6 +169,33 @@ test_that("folder_to_include works", {
   pkg_devdir <- names(local_renv_devdir$data()$Packages)
   # glue and extrapackage in dev/ are there
   expect_true(all(c("glue", "extrapackage") %in% pkg_devdir))
+})
+
+# Test pkg_ignore works ----
+# extrapackage is in "dev/" but I want it to be ignored
+test_that("create_renv_(pkg_ignore) works", {
+
+  lock_includes_ignore <- file.path(tmpdir, "for_ignore.lock")
+  expect_message({my_renv_ignore <-
+    create_renv_for_dev(
+      path = dummypackage,
+      install_if_missing = FALSE,
+      output = lock_includes_ignore,
+      pkg_ignore = "extrapackage",
+      force = TRUE)}
+  )
+
+  expect_true(file.exists(lock_includes_ignore))
+  expect_true(file.exists(my_renv_ignore))
+
+  local_renv_ignore <- getFromNamespace("lockfile", "renv")(my_renv_ignore)
+  expect_s3_class(local_renv_ignore, "renv_lockfile_api")
+
+  pkg_ignore <- names(local_renv_ignore$data()$Packages)
+  # glue and  in dev/ are there
+  expect_true(all(c("glue") %in% pkg_ignore))
+  # extrapackage is ignored in dev/
+  expect_false(all(c("extrapackage") %in% pkg_ignore))
 })
 
 remove.packages("extrapackage")


### PR DESCRIPTION
Why?

Some packages listed in dev/ dir may not be in use

What?

Allow to ignore packages from being used as main deps