### PR TITLE
fix: allow run func with deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ BugReports: https://github.com/Thinkr-open/attachment/issues
 VignetteBuilder:
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 Depends: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 # attachment (development version)
+## Minor changes
+
+## Bug fixes 
+
+* Allow to use dependencies after `att_amend_desc()` #52
 
 # attachment 0.2.5
 ## Major changes

--- a/R/att_from_namespace.R
+++ b/R/att_from_namespace.R
@@ -35,6 +35,7 @@ att_from_namespace <- function(path = "NAMESPACE", document = TRUE, clean = TRUE
     }
     withr::with_dir(dirname(path), {
       roxygenise(dirname(path), roclets = NULL)
+      roxygen2::load_pkgload(path = path)
     })
   }
   base <- try(readLines(path), silent = TRUE)

--- a/dev/dev_history.R
+++ b/dev/dev_history.R
@@ -104,6 +104,9 @@ install.packages("glue")
 rstudioapi::restartSession()
 devtools::test()
 
+# Test specific interactive ----
+devtools::load_all()
+testthat::test_file(here::here("tests/testthat/test-amend-description.R"))
 
 # Checks for CRAN release ----
 # Check package as CRAN

--- a/man/attachment-package.Rd
+++ b/man/attachment-package.Rd
@@ -6,7 +6,7 @@
 \alias{attachment-package}
 \title{attachment: Deal with Dependencies}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
 Tools to help manage dependencies during package development. This can retrieve all dependencies that are used in R files in the "R" directory, in Rmd files in "vignettes" directory and in 'roxygen2' documentation of functions. There is a function to update the Description file of your package and a function to create a file with the R commands to install all dependencies of your package. All functions to retrieve dependencies of R scripts and Rmd files can be used independently of a package development.
 }


### PR DESCRIPTION
Tags: fix, test

Why?

- When running att_amend_desc(), this was not possible to run internal
function as namespace disappears

What?

- load package functions after roxygenise

Issues
closes #52