### PR TITLE
feat: deal local package dependencies

### DIFF
--- a/R/set_remotes.R
+++ b/R/set_remotes.R
@@ -150,6 +150,8 @@ extract_pkg_info <- function(pkgdesc) {
       } else if (!is.null(desc$RemoteType) && desc$RemoteType %in% c("gitlab", "bitbucket")) {
         tolower(paste0(desc$RemoteType, "::",
                        paste(desc$RemoteUsername, desc$RemoteRepo, sep = "/")))
+      } else if (desc$RemoteType == "local" && !is.null(desc$RemoteUrl)  && is.null(desc$RemoteHost)) {
+        tolower(paste0(desc$RemoteType, "::", desc$RemoteUrl))
       } else if (!is.null(desc$RemoteType) && is.null(desc$RemoteHost)) {
         c("Maybe ?" = tolower(paste0(desc$RemoteType, "::", desc$RemoteHost, ":",
                                      paste(desc$RemoteUsername, desc$RemoteRepo, sep = "/"))))

--- a/vignettes/a-fill-pkg-description.Rmd
+++ b/vignettes/a-fill-pkg-description.Rmd
@@ -68,6 +68,7 @@ For instance:
 
 - For GitHub : `Remotes: thinkr-open/attachment`
 - For GitLab : `Remotes: gitlab::jimhester/covr`
+- For local package: `Remotes: local::c:\mylocalpackage`
 
 You may want to run it after `att_amend_desc()`.
 


### PR DESCRIPTION
tags: feat, doc, test

Why ?

- deal local package dependencies (from path to compressed file or local directory)

What ?

- Improve extract_pkg_info() to consider local package (+test)
- set_remotes_to_desc(): add test to consider local package
- Complete vignette part `set_remotes_to_desc()`

Issues

Issue
#54