### PR TITLE
Make requirement of `Suggests` package optional

### DIFF
--- a/R/att_to_description.R
+++ b/R/att_to_description.R
@@ -41,7 +41,8 @@ att_amend_desc <- function(path = ".",
                            document = TRUE,
                            normalize = TRUE,
                            inside_rmd = FALSE,
-                           must.exist = TRUE
+                           must.exist = TRUE,
+                           require_suggests = FALSE
 ) {
 
 
@@ -159,7 +160,7 @@ att_amend_desc <- function(path = ".",
   suggests <- suggests[suggests != "base"]
 
   # Build DESCRIPTION ----
-  att_to_desc_from_is(path.d, imports, suggests, normalize, must.exist)
+  att_to_desc_from_is(path.d, imports, suggests, normalize, must.exist, require_suggests = require_suggests)
 }
 
 #' @rdname att_amend_desc
@@ -171,6 +172,7 @@ att_to_desc_from_pkg <- att_amend_desc
 #' @param path.d path to description file.
 #' @param imports character vector of package names to add in Imports section
 #' @param suggests character vector of package names to add in Suggests section
+#' @param require_suggests Logical. Whether to require that packages in the Suggests section are installed.
 #' @param normalize Logical. Whether to normalize the DESCRIPTION file. See [desc::desc_normalize()]
 #' @param must.exist Logical. If TRUE then an error is given if packages do not exist
 #' within installed packages. If NA, a warning.
@@ -203,7 +205,7 @@ att_to_desc_from_pkg <- att_amend_desc
 #' suggests = att_from_rmds(file.path(dummypackage, "vignettes")))
 
 att_to_desc_from_is <- function(path.d = "DESCRIPTION", imports = NULL,
-                                suggests = NULL, normalize = TRUE,
+                                suggests = NULL, require_suggests = TRUE, normalize = TRUE,
                                 must.exist = TRUE) {
 
   if (!file.exists(path.d)) {
@@ -226,9 +228,12 @@ att_to_desc_from_is <- function(path.d = "DESCRIPTION", imports = NULL,
 
   # rlang::check_installed("pkg")
   # imports
+  check_installed <- c(imports)
+  if (require_suggests)
+    check_installed <- c(check_installed, suggests)
   suppressWarnings(
     res <- vapply(
-      c(imports, suggests), FUN = requireNamespace,
+      check_installed, FUN = requireNamespace,
       FUN.VALUE = logical(1), quietly = TRUE)
   )
   missing_packages <- names(res[!res])

--- a/R/create_renv.R
+++ b/R/create_renv.R
@@ -29,6 +29,7 @@ extra_dev_pkg <- c(
 #' detecting packages in DESCRIPTION.
 #' @param pkg_ignore Vector of packages to ignore from being discovered in your files.
 #' This does not prevent them to be in "renv.lock" if they are recursive dependencies.
+#' @inheritParams att_to_desc_from_is
 #' @param ... Other arguments to pass to [renv::snapshot()]
 #'
 #' @return a renv.lock file
@@ -50,6 +51,7 @@ create_renv_for_dev <- function(path = ".",
                                 install_if_missing = TRUE,
                                 document = TRUE,
                                 pkg_ignore = NULL,
+                                require_suggests = FALSE,
                                 ...) {
 
   if (!requireNamespace("renv")) {
@@ -66,7 +68,7 @@ create_renv_for_dev <- function(path = ".",
   }
 
   if (isTRUE(document)) {
-    att_amend_desc(path)
+    att_amend_desc(path, require_suggests = require_suggests)
   }
 
   pkg_list <- unique(

--- a/man/att_amend_desc.Rd
+++ b/man/att_amend_desc.Rd
@@ -17,7 +17,8 @@ att_amend_desc(
   document = TRUE,
   normalize = TRUE,
   inside_rmd = FALSE,
-  must.exist = TRUE
+  must.exist = TRUE,
+  require_suggests = FALSE
 )
 
 att_to_desc_from_pkg(
@@ -32,7 +33,8 @@ att_to_desc_from_pkg(
   document = TRUE,
   normalize = TRUE,
   inside_rmd = FALSE,
-  must.exist = TRUE
+  must.exist = TRUE,
+  require_suggests = FALSE
 )
 }
 \arguments{
@@ -61,6 +63,8 @@ in case this must be executed in an external R session}
 
 \item{must.exist}{Logical. If TRUE then an error is given if packages do not exist
 within installed packages. If NA, a warning.}
+
+\item{require_suggests}{Logical. Whether to require that packages in the Suggests section are installed.}
 }
 \value{
 Update DESCRIPTION file.

--- a/man/att_to_desc_from_is.Rd
+++ b/man/att_to_desc_from_is.Rd
@@ -8,6 +8,7 @@ att_to_desc_from_is(
   path.d = "DESCRIPTION",
   imports = NULL,
   suggests = NULL,
+  require_suggests = TRUE,
   normalize = TRUE,
   must.exist = TRUE
 )
@@ -18,6 +19,8 @@ att_to_desc_from_is(
 \item{imports}{character vector of package names to add in Imports section}
 
 \item{suggests}{character vector of package names to add in Suggests section}
+
+\item{require_suggests}{Logical. Whether to require that packages in the Suggests section are installed.}
 
 \item{normalize}{Logical. Whether to normalize the DESCRIPTION file. See \code{\link[desc:desc_normalize]{desc::desc_normalize()}}}
 

--- a/man/create_renv_for_dev.Rd
+++ b/man/create_renv_for_dev.Rd
@@ -13,6 +13,7 @@ create_renv_for_dev(
   install_if_missing = TRUE,
   document = TRUE,
   pkg_ignore = NULL,
+  require_suggests = FALSE,
   ...
 )
 
@@ -42,6 +43,8 @@ detecting packages in DESCRIPTION.}
 
 \item{pkg_ignore}{Vector of packages to ignore from being discovered in your files.
 This does not prevent them to be in "renv.lock" if they are recursive dependencies.}
+
+\item{require_suggests}{Logical. Whether to require that packages in the Suggests section are installed.}
 
 \item{...}{Other arguments to pass to \code{\link[renv:snapshot]{renv::snapshot()}}}
 }


### PR DESCRIPTION
It is rarely the case that packages in the Suggests field are needed when deploying a `golem` app. R does not install Suggests packages when packages are downloaded, and thus the the build process for Dockerfiles should not require that packages listed in `Suggests` be installed for deployment. 

This adds an argument `require_suggests` to the following functions:
 - `create_renv_for_dev`
 - `att_amend_desc`
 - `att_to_desc_from_is`
in order to be passed down from `golem::add_dockerfile_with_renv_`, which will be in a related PR on `golem`.