### PR TITLE
feat: Allow params from config for att_amend_desc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: attachment
 Title: Deal with Dependencies
-Version: 0.3.1.9001
+Version: 0.3.1.9002
 Authors@R:
     c(person(given = "Sébastien",
              family = "Rochette",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# attachment 0.3.1.9002
+
+- `att_amend_desc()` gets parameters `update.config = FALSE`, `use.config = FALSE` and `path.c = "dev/config_attachment.yaml"` by default. It allows to store and re-use the provided set of parameters.
+
 # attachment 0.3.1.9000
 
 - `create_dependencies_file()` now takes other sources into account (git, gitlab, github, bioc, local)

--- a/dev/config_attachment.yaml
+++ b/dev/config_attachment.yaml
@@ -1,0 +1,27 @@
+path: '.'
+path.n: NAMESPACE
+path.d: DESCRIPTION
+dir.r: R
+dir.v: vignettes
+dir.t: ''
+extra.suggests:
+- testthat
+- rstudioapi
+- renv
+- lifecycle
+pkg_ignore:
+- remotes
+- i
+- usethis
+- rstudioapi
+- renv
+- gitlab
+- git
+- local
+- find.rscript
+- bioc
+document: yes
+normalize: no
+inside_rmd: no
+must.exist: yes
+check_if_suggests_is_installed: yes

--- a/dev/dev_history.R
+++ b/dev/dev_history.R
@@ -84,7 +84,8 @@ attachment::att_amend_desc(
                  "gitlab", "git", "local", "find.rscript", "bioc"), #i
   extra.suggests = c("testthat", "rstudioapi", "renv", "lifecycle"), #"pkgdown", "covr",
   dir.t = "",
-  normalize = FALSE)
+  normalize = FALSE,
+  update.config = TRUE)
 
 attachment::create_dependencies_file(field = c("Depends", "Imports", "Suggests"))
 

--- a/dev/flat_save_att_params.Rmd
+++ b/dev/flat_save_att_params.Rmd
@@ -290,12 +290,9 @@ test_that("load_att_params works", {
 # Execute in the console directly
 fusen::inflate(flat_file = "dev/flat_save_att_params.Rmd",
                vignette_name = "Save attachment config",
+               overwrite = TRUE,
                document = FALSE)
 
-
-rstudioapi::navigateToFile( # Go to the dev_history.R to run att_amend_desc()
-  "dev/dev_history.R",
-  line = 82
-)
+att_amend_desc(use.config = TRUE)
 ```
 

--- a/man/att_amend_desc.Rd
+++ b/man/att_amend_desc.Rd
@@ -18,7 +18,10 @@ att_amend_desc(
   normalize = TRUE,
   inside_rmd = FALSE,
   must.exist = TRUE,
-  check_if_suggests_is_installed = TRUE
+  check_if_suggests_is_installed = TRUE,
+  update.config = FALSE,
+  use.config = FALSE,
+  path.c = "dev/config_attachment.yaml"
 )
 
 att_to_desc_from_pkg(
@@ -34,7 +37,10 @@ att_to_desc_from_pkg(
   normalize = TRUE,
   inside_rmd = FALSE,
   must.exist = TRUE,
-  check_if_suggests_is_installed = TRUE
+  check_if_suggests_is_installed = TRUE,
+  update.config = FALSE,
+  use.config = FALSE,
+  path.c = "dev/config_attachment.yaml"
 )
 }
 \arguments{
@@ -65,6 +71,12 @@ in case this must be executed in an external R session}
 within installed packages. If NA, a warning.}
 
 \item{check_if_suggests_is_installed}{Logical. Whether to require that packages in the Suggests section are installed.}
+
+\item{update.config}{logical Should the parameters used in this call be saved in the config file of the pkg}
+
+\item{use.config}{logical Should the command use the parameters from the config file to run}
+
+\item{path.c}{character Path to the yaml config file where parameters are saved}
 }
 \value{
 Update DESCRIPTION file.


### PR DESCRIPTION
Why?
- enable to retrieve parameter from a config when running `att_amend_desc()`
- enable to launch `att_amend_desc()` from console with correct params without going back to dev_history file by using `use.config = TRUE`

What?
- add three yaml params in att_amend_desc to save/use/update config yaml file
- based on these params, reassign parameter to saved values or save current parameters to yaml or do nothing

issue #75