### PR TITLE
test : Add test for att_amen_desc() errors message

### DIFF
--- a/tests/testthat/test-amend-description.R
+++ b/tests/testthat/test-amend-description.R
@@ -525,6 +525,15 @@ test_that("att_amend_desc can create, use and update config file", {
   desc_file <- readLines(file.path(dummypackage, "DESCRIPTION"))
   expect_equal(desc_file[grep("Suggests: ", desc_file) + 1], "    ggplot2,")
 
+  # error when trying to use and update config at the same time
+  expect_error(
+    object =att_amend_desc(
+      path = dummypackage,
+      use.config = TRUE,
+      update.config = TRUE),
+    regexp = "Cannot use and update config at the same time"
+  )
+
   # Clean after
   unlink(dummypackage, recursive = TRUE)
 })


### PR DESCRIPTION
Why?
- no test present to test an error is reported when use.config = TRUE et update.config = TRUE

What?
- add a test

issue #92