### PR TITLE
Fix test cran

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,4 @@ img
 ^revdep$
 ^CRAN-SUBMISSION$
 ^attachment\.Rproj$
+^CONTRIBUTING\.md$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to attachment
+
+This outlines how to propose a change to attachment. 
+For more detailed info about contributing to this, and other tidyverse packages, please see the
+[**development contributing guide**](https://rstd.io/tidy-contrib). 
+
+## All contribution welcomed
+
+We are open to any contribution, from typos to new features. We will guide you throughout the process and make you in a safe position to contribute, whatever is your level in R programming.
+
+## Package versions required to develop
+
+- `{roxygen2}`: Version > `7.1.2` is required.
+
+## Fixing typos
+
+You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the _source_ file. 
+This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file. 
+You can find the `.R` file that generates the `.Rd` by reading the comment in the first line.
+
+## Bigger changes
+
+If you want to make a bigger change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed. 
+If you’ve found a bug, please file an issue that illustrates the bug with a minimal 
+[reprex](https://www.tidyverse.org/help/#reprex) (this will also help you write a unit test, if needed).
+
+### Pull request process
+
+*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("ThinkR-open/attachment", fork = TRUE)`.
+
+*   Install all development dependencies with `devtools::install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
+    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
+*   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
+
+*   Make your changes, commit to git, and then create a PR by running `usethis::pr_push()`, and following the prompts in your browser.
+    The title of your PR should briefly describe the change.
+    The body of your PR should contain `Fixes #issue-number`.
+
+*  For user-facing changes, add a bullet to the top of `NEWS.md` (i.e. just below the first header). Follow the style described in <https://style.tidyverse.org/news.html>.
+
+### Code style
+
+*   New code should follow the tidyverse [style guide](https://style.tidyverse.org). 
+    You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR.  
+
+*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.  
+
+*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. 
+   Contributions with test cases included are easier to accept.  
+
+## Code of Conduct
+
+Please note that the attachment project is released with a
+[Contributor Code of Conduct](https://github.com/ThinkR-open/attachment/blob/main/CODE_OF_CONDUCT.md). By contributing to this
+project you agree to abide by its terms.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: attachment
 Title: Deal with Dependencies
-Version: 0.4.0.9000
+Version: 0.4.0.9001
 Authors@R: c(
     person("Sébastien", "Rochette", , "sebastien@thinkr.fr", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-1565-9313")),
@@ -31,7 +31,7 @@ Config/Needs/website: ThinkR-open/thinkrtemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Depends: 
     R (>= 3.4)
 Imports: 
@@ -52,3 +52,4 @@ Suggests:
     renv (>= 0.8.4),
     rstudioapi,
     testthat (>= 3.0.0)
+Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
-# attachment 0.4.0.9000
+# attachment 0.4.0.9001
 
+## Bug fixes 
+
+- Modification of unit tests following {roxygen2} changes. `att_amend_desc` and `att_from_namespace` return messages instead of warnings. (@MurielleDelmotte) 
 
 # attachment 0.4.0
 

--- a/dev/dev_history.R
+++ b/dev/dev_history.R
@@ -8,6 +8,11 @@ usethis::use_travis()
 usethis::use_news_md()
 usethis::use_pkgdown()
 
+# contributing
+usethis::use_tidy_contributing()
+usethis::use_build_ignore("CONTRIBUTING.md")
+
+
 usethis::use_code_of_conduct(contact = "sebastien@thinkr.fr")
 
 library(desc)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,6 @@
+test_that("Package version required", {
+
+  # Check the version of the package roxygen2 to take into account the breaking change.
+  expect_true(packageVersion("roxygen2") > "7.1.2")
+
+})

--- a/tests/testthat/test-att_from_namespace.R
+++ b/tests/testthat/test-att_from_namespace.R
@@ -86,9 +86,20 @@ writeLines(enc2utf8(lines), r_file)
 
 test_that("bad namespace can be corrected", {
   # expect_warning(cli::cli_warn("toto"), regexp = "tota")
-  # roxygen > 7.1.2 does not let a bad NAMESPACE happen
-  if (packageVersion("roxygen2") > "7.1.2") {
-    # "must have at least 2 words, not 1"
+
+  # Check that the information transmitted by roxygen2 is correctly retransmitted by attachment
+
+  if (packageVersion("roxygen2") >= "7.3.0") {
+    # roxygen > 7.3.0 generates a message
+
+    expect_message(att_amend_desc(dummypackage),
+                   "must have at least 2 words, not 1")
+
+    # Still message because of r_file but no error
+    expect_message(att_from_namespace(path = file.path(dummypackage, "NAMESPACE"),
+                                      document = TRUE, clean = TRUE))
+  } else {
+    # roxygen > 7.1.2 generates a warning
     expect_warning(att_amend_desc(dummypackage),
                    "must have at least 2 words, not 1")
     # Hence no error
@@ -99,15 +110,13 @@ test_that("bad namespace can be corrected", {
           document = TRUE, clean = FALSE)
       ),
       regexp = NA)
-  } else {
-    expect_warning(att_amend_desc(dummypackage))
-    expect_error(
-      att_from_namespace(path = file.path(dummypackage, "NAMESPACE"),
-                         document = TRUE, clean = FALSE))
+
+    # Still warning because of r_file but no error
+    expect_warning(att_from_namespace(path = file.path(dummypackage, "NAMESPACE"),
+                                      document = TRUE, clean = TRUE))
   }
-  # Still warning because of r_file but no error
-  expect_warning(att_from_namespace(path = file.path(dummypackage, "NAMESPACE"),
-                                  document = TRUE, clean = TRUE))
+
+
   # Correct R function, no warning, no error
   writeLines(enc2utf8(lines_orig), r_file)
   deps <- att_from_namespace(path = file.path(dummypackage, "NAMESPACE"),


### PR DESCRIPTION
fix: test avec roxygen2 >=7.3.0

why:
- with roxygen2 v7.3.0, tests fail (att_from_namespace)
- roxygen2 now returns a message instead of a warning

what:
- added a condition on the roxygen2 version to test a message or warning
- check a minimum version for roxygen2 (>7.1.2)
- removes testing on versions prior to 7.1.2

issue https://github.com/ThinkR-open/attachment/issues/107