### PR TITLE
feat create_renv_for_dev can work even outside of an R packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: attachment
 Title: Deal with Dependencies
-Version: 0.4.1.9000
+Version: 0.4.1.9001
 Authors@R: c(
     person("Sébastien", "Rochette", , "sebastien@thinkr.fr", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-1565-9313")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # attachment (development version)
 
+## New features
+
+-`create_renv_for_dev` can work even outside of an R packages
+
 # attachment 0.4.1
 
 ## Bug fixes 

--- a/R/create_renv.R
+++ b/R/create_renv.R
@@ -59,7 +59,6 @@ create_renv_for_dev <- function(path = ".",
     stop("'renv' is required. Please install it before.")
   }
 
-  path_orig <- path
   path <- normalizePath(path)
 
   if (!is.null(dev_pkg) && "_default" %in% dev_pkg) {
@@ -110,7 +109,7 @@ create_renv_for_dev <- function(path = ".",
   )} else {
     cli::cli_alert_info("No DESCRIPTION file found")
     cli::cli_alert_info(      paste(
-      "we wil parse qmd files,Rmd files and R scripts i ",path,
+      "we wil parse qmd files,Rmd files and R scripts from ",path,
       "."
     ))
 

--- a/R/create_renv.R
+++ b/R/create_renv.R
@@ -59,6 +59,7 @@ create_renv_for_dev <- function(path = ".",
     stop("'renv' is required. Please install it before.")
   }
 
+  path_orig <- path
   path <- normalizePath(path)
 
   if (!is.null(dev_pkg) && "_default" %in% dev_pkg) {
@@ -67,6 +68,11 @@ create_renv_for_dev <- function(path = ".",
             paste(extra_dev_pkg, collapse = ", ")))
     dev_pkg <- c(extra_dev_pkg, dev_pkg[dev_pkg != "_default"])
   }
+
+
+# s'il n y pas de fichier DESCRIPTION on va chercher l'information ailleurs
+
+  if (file.exists(file.path(path, "DESCRIPTION"))){
 
   if (isTRUE(document)) {
     # Use a temporary config_file for renv
@@ -101,7 +107,23 @@ create_renv_for_dev <- function(path = ".",
       att_from_description(path = file.path(path, "DESCRIPTION"),field = fields),
       dev_pkg
     )
-  )
+  )} else {
+    cli::cli_alert_info("No DESCRIPTION file found")
+    cli::cli_alert_info(      paste(
+      "we wil parse qmd files,Rmd files and R scripts i ",path,
+      "."
+    ))
+
+
+    pkg_list <- unique(
+      c(
+        att_from_qmds(path = path,recursive = TRUE),
+        att_from_rmds(path = path,recursive = TRUE),
+        att_from_rscripts(path = path,recursive = TRUE),
+        dev_pkg
+      )
+    )
+  }
 
   # Extra folders
   folder_to_include_relative <- folder_to_include

--- a/inst/dummyfolder/global.R
+++ b/inst/dummyfolder/global.R
@@ -1,0 +1,2 @@
+library(dplyr)
+library(sudoku)

--- a/inst/dummyfolder/global.R
+++ b/inst/dummyfolder/global.R
@@ -1,2 +1,2 @@
-library(dplyr)
-library(sudoku)
+library(extrapackage)
+library(glue)

--- a/inst/dummyfolder/server.R
+++ b/inst/dummyfolder/server.R
@@ -1,0 +1,28 @@
+#
+# This is the server logic of a Shiny web application. You can run the
+# application by clicking 'Run App' above.
+#
+# Find out more about building applications with Shiny here:
+#
+#    http://shiny.rstudio.com/
+#
+
+library(shiny)
+
+# Define server logic required to draw a histogram
+function(input, output, session) {
+
+    output$distPlot <- renderPlot({
+
+        # generate bins based on input$bins from ui.R
+        x    <- faithful[, 2]
+        bins <- seq(min(x), max(x), length.out = input$bins + 1)
+
+        # draw the histogram with the specified number of bins
+        hist(x, breaks = bins, col = 'darkgray', border = 'white',
+             xlab = 'Waiting time to next eruption (in mins)',
+             main = 'Histogram of waiting times')
+
+    })
+
+}

--- a/inst/dummyfolder/server.R
+++ b/inst/dummyfolder/server.R
@@ -7,7 +7,7 @@
 #    http://shiny.rstudio.com/
 #
 
-library(shiny)
+# library(shiny)
 
 # Define server logic required to draw a histogram
 function(input, output, session) {

--- a/inst/dummyfolder/ui.R
+++ b/inst/dummyfolder/ui.R
@@ -1,0 +1,33 @@
+#
+# This is the user-interface definition of a Shiny web application. You can
+# run the application by clicking 'Run App' above.
+#
+# Find out more about building applications with Shiny here:
+#
+#    http://shiny.rstudio.com/
+#
+
+library(shiny)
+
+# Define UI for application that draws a histogram
+fluidPage(
+
+    # Application title
+    titlePanel("Old Faithful Geyser Data"),
+
+    # Sidebar with a slider input for number of bins
+    sidebarLayout(
+        sidebarPanel(
+            sliderInput("bins",
+                        "Number of bins:",
+                        min = 1,
+                        max = 50,
+                        value = 30)
+        ),
+
+        # Show a plot of the generated distribution
+        mainPanel(
+            plotOutput("distPlot")
+        )
+    )
+)

--- a/inst/dummyfolder/ui.R
+++ b/inst/dummyfolder/ui.R
@@ -7,7 +7,7 @@
 #    http://shiny.rstudio.com/
 #
 
-library(shiny)
+# library(shiny)
 
 # Define UI for application that draws a histogram
 fluidPage(

--- a/tests/testthat/test-renv_create2.R
+++ b/tests/testthat/test-renv_create2.R
@@ -1,0 +1,49 @@
+# These tests can not run on CRAN
+skip_on_cran()
+
+if (length(find.package("extrapackage", quiet = TRUE)) != 0) {
+  unlink(find.package("extrapackage", quiet = TRUE), recursive = TRUE)
+}
+
+# test on dummy package
+tmpdir <- tempfile(pattern = "pkgrenv2")
+dir.create(tmpdir)
+file.copy(
+  system.file("dummyfolder", package = "attachment"), tmpdir,
+  recursive = TRUE
+)
+dummyfolder <- file.path(tmpdir, "dummyfolder")
+lock_ <- file.path(tmpdir, "my_lock.lock")
+
+
+  expect_message({
+
+    my_renv_ <- create_renv_for_dev(
+      path = dummyfolder,
+      install_if_missing = FALSE,
+      output = lock_,
+      # force generation of a lockfile even when pre-flight validation checks have failed?
+      force = TRUE)}
+  )
+
+
+
+
+
+test_that("create_renv_for_dev creates lock files even without DESCRIPTION file", {
+  expect_true(file.exists(lock_))
+})
+
+# print(my_renv_extra)
+
+
+renv_content <- getFromNamespace("lockfile", "renv")(my_renv_)
+
+
+test_that("lockfile are correct renv files", {
+expect_s3_class(renv_content, "renv_lockfile_api")
+expect_true("dplyr" %in% names(renv_content$data()$Packages))
+expect_true("sudoku" %in% names(renv_content$data()$Packages))
+})
+
+

--- a/tests/testthat/test-renv_create2.R
+++ b/tests/testthat/test-renv_create2.R
@@ -13,6 +13,49 @@ file.copy(
   recursive = TRUE
 )
 dummyfolder <- file.path(tmpdir, "dummyfolder")
+
+
+
+
+
+
+
+# Create a second dummy package that will be a dependance of dummy
+# So that, we are sure it does not exists on CRAN for extra checks
+extra_path <- file.path(tmpdir, "dummy.extra")
+dir.create(extra_path, recursive = TRUE)
+file.copy(
+  system.file("dummypackage", package = "attachment"),
+  extra_path,
+  recursive = TRUE
+)
+extrapackage <- file.path(extra_path, "extrapackage")
+file.rename(file.path(extra_path, "dummypackage"), extrapackage)
+# Rename package and remove 'Rcpp'
+desc_lines <- readLines(file.path(extrapackage, "DESCRIPTION"))
+desc_lines <- gsub("dummypackage", "extrapackage", desc_lines)
+desc_lines <- desc_lines[-grep("LinkingTo|Rcpp", desc_lines)]
+cat(desc_lines, sep = "\n", file = file.path(extrapackage, "DESCRIPTION"))
+# Remove calls to 'dummypackage' and 'Rcpp'
+unlink(file.path(extrapackage, "tests"), recursive = TRUE)
+# document
+# inuse <- search()
+att_amend_desc(path = extrapackage)
+unloadNamespace("extrapackage") # for windows mainly
+# Install package to make it available to {renv}
+install.packages(extrapackage, repos = NULL, type = "source")
+
+
+
+
+
+
+
+
+
+
+
+
 lock_ <- file.path(tmpdir, "my_lock.lock")
 
 
@@ -42,8 +85,8 @@ renv_content <- getFromNamespace("lockfile", "renv")(my_renv_)
 
 test_that("lockfile are correct renv files", {
 expect_s3_class(renv_content, "renv_lockfile_api")
-expect_true("dplyr" %in% names(renv_content$data()$Packages))
-expect_true("sudoku" %in% names(renv_content$data()$Packages))
+expect_true("glue" %in% names(renv_content$data()$Packages))
+expect_true("extrapackage" %in% names(renv_content$data()$Packages))
 })
 
 


### PR DESCRIPTION
The modification introduced enables the function `create_renv_for_dev` to generate a renv.lock file even when executed outside of a package. The purpose is to allow this function to read a directory containing files such as ui.R and global.R, for instance.