### PR TITLE
fix: filter .R files correctly in att_from_examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: attachment
 Title: Deal with Dependencies
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(
     person("Vincent", "Guyader", , "vincent@thinkr.fr", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0003-0671-9270")),
-    person("Sébastien", "Rochette", , "sebastien@thinkr.fr", role = c("aut"),
+    person("Sébastien", "Rochette", , "sebastienrochettefr@gmail.com", role = c("aut"),
            comment = c(ORCID = "0000-0002-1565-9313", "previous maintainer")),
     person("Murielle", "Delmotte", , "murielle@thinkr.fr", role = "aut",
            comment = c(ORCID = "0000-0002-1339-2424")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# attachment 0.4.4
+
+## Patch
+
+- `att_from_examples()` Fixed the selection of `.R` files in the source directory. (#124)
+
 # attachment 0.4.3
 
 ## New features

--- a/R/add_from_examples.R
+++ b/R/add_from_examples.R
@@ -12,7 +12,7 @@
 
 #' @export
 att_from_examples <- function(dir.r = "R") {
-  rfiles <- list.files(dir.r, full.names = TRUE)
+  rfiles <- list.files(dir.r, full.names = TRUE, pattern = "\\.r$", ignore.case = TRUE,recursive = FALSE)
 
   roxy_file <- tempfile("roxy.examples", fileext = ".R")
 

--- a/tests/testthat/test-att_from_examples.R
+++ b/tests/testthat/test-att_from_examples.R
@@ -22,3 +22,29 @@ my_length <- function(x) {
                c("magrittr", "fakepkg"))
 
 })
+test_that("att_from_examples works even with sysdata.rda", {
+  tmpdir <- tempfile("suggestexamples")
+
+  dir.create(file.path(tmpdir, "R"), recursive = TRUE)
+
+  r_file <- file.path(tmpdir, "R", "fun_manual.R")
+  file.create(r_file)
+
+  writeLines(
+    text = "#' @importFrom magrittr %>%
+#' @examples
+#' library(magrittr)
+#' fakepkg::fun()
+#' @export
+my_length <- function(x) {
+  x %>% length()
+}",
+    con = r_file
+  )
+
+  save(iris,file = file.path(tmpdir,"R","sysdata.rda"),compress = "bzip2",version = 3,ascii = FALSE)
+
+  expect_equal(att_from_examples(dir.r = file.path(tmpdir, "R")),
+               c("magrittr", "fakepkg"))
+
+})


### PR DESCRIPTION
Replaced list.files call to only include files ending with .R using a pattern, ensuring case-insensitive matching and avoiding unnecessary recursion.

fix #124 