### PR TITLE
test(renv): assert lockfile package names instead of grepping raw JSON

### DIFF
--- a/tests/testthat/test-renv_create.R
+++ b/tests/testthat/test-renv_create.R
@@ -311,10 +311,16 @@ test_that("suggested package are not in renv prod", {
     # check_if_suggests_is_installed = FALSE,
     force = TRUE)
 
-  base <- paste(readLines(out_renv_file),collapse = " ")
-  expect_false(grepl(pattern = "idontexist",x = base))
-  expect_false(grepl(pattern = "withr",x = base))
-  expect_true(grepl(pattern = "magrittr",x = base))
+  # Parse the lockfile and inspect *top-level* package names rather than
+  # grepping raw JSON text — otherwise a Suggests entry inside another
+  # package's metadata (e.g. `withr` listed under remotes' Suggests) would
+  # leak as a false positive.
+  pkg_in_lock <- names(
+    getFromNamespace("lockfile", "renv")(out_renv_file)$data()$Packages
+  )
+  expect_false("idontexist" %in% pkg_in_lock)
+  expect_false("withr" %in% pkg_in_lock)
+  expect_true("magrittr" %in% pkg_in_lock)
 
   unlink(dummypackage, recursive = TRUE)
 }
@@ -411,12 +417,14 @@ test_that("suggested package are not in renv prod even from vignettes", {
     # check_if_suggests_is_installed = FALSE,
     force = TRUE)
 
-  base <- paste(readLines(out_renv_file),collapse = " ")
-  expect_false(grepl(pattern = "idontexist",x = base))
-  expect_false(grepl(pattern = "withr",x = base))
-  expect_false(grepl(pattern = "ggplot3",x = base))
-  expect_false(grepl(pattern = "glue",x = base))
-  expect_true(grepl(pattern = "magrittr",x = base))
+  pkg_in_lock <- names(
+    getFromNamespace("lockfile", "renv")(out_renv_file)$data()$Packages
+  )
+  expect_false("idontexist" %in% pkg_in_lock)
+  expect_false("withr" %in% pkg_in_lock)
+  expect_false("ggplot3" %in% pkg_in_lock)
+  expect_false("glue" %in% pkg_in_lock)
+  expect_true("magrittr" %in% pkg_in_lock)
 
   unlink(dummypackage, recursive = TRUE)
   file.remove(out_renv_file)
@@ -462,12 +470,14 @@ test_that("suggested package are not in renv prod even from vignettes", {
     # check_if_suggests_is_installed = FALSE,
     force = TRUE)
 
-  base <- paste(readLines(out_renv_file),collapse = " ")
-  expect_false(grepl(pattern = "idontexist",x = base))
-  expect_false(grepl(pattern = "withr",x = base))
-  expect_false(grepl(pattern = "ggplot3",x = base))
-  expect_false(grepl(pattern = "glue",x = base))
-  expect_true(grepl(pattern = "magrittr",x = base))
+  pkg_in_lock <- names(
+    getFromNamespace("lockfile", "renv")(out_renv_file)$data()$Packages
+  )
+  expect_false("idontexist" %in% pkg_in_lock)
+  expect_false("withr" %in% pkg_in_lock)
+  expect_false("ggplot3" %in% pkg_in_lock)
+  expect_false("glue" %in% pkg_in_lock)
+  expect_true("magrittr" %in% pkg_in_lock)
 
   unlink(dummypackage, recursive = TRUE)
   file.remove(out_renv_file)


### PR DESCRIPTION
## Problem

Three tests in `tests/testthat/test-renv_create.R` (`suggested package are not in renv prod`, lines 316/416/467 on main) grep the lockfile JSON as a flat string:

```r
base <- paste(readLines(out_renv_file), collapse = " ")
expect_false(grepl(pattern = "withr", x = base))
```

This matches **any** textual mention of `withr` in the file — including a `Suggests:` field inside another package's metadata. After `remotes 2.5.0` shipped with `withr` listed in *its* Suggests, every prod-lockfile run pulls in `remotes` (it's used by `attachment::set_remotes`), and the grep finds:

```json
"remotes": {
  ...
  "Suggests": [ "...", "withr" ]
}
```

…which is a metadata mention, not a top-level package of the lockfile.

`skip_on_cran()` hides the failures from R CMD check, so CI stayed green; the fails only surface when running `devtools::test()` locally with `NOT_CRAN=true`.

## Fix

Switch to parsing the lockfile via `renv:::lockfile()` and asserting membership in `names(...$data()$Packages)`. This is the same idiom already used at `test-renv_create.R:128-143` for the dev/prod lockfile checks higher up in the file — just applied consistently to the three lower test_that blocks too.

Three `expect_false(grepl(...))` blocks become three `expect_false("X" %in% pkg_in_lock)` blocks. No semantic change in what the tests *intend* to assert; only the implementation is hardened against textual false positives.

## Coverage

- `test-renv_create.R:316` — `suggested package are not in renv prod`
- `test-renv_create.R:416` — `suggested package are not in renv prod even from vignettes` (with `document = FALSE`)
- `test-renv_create.R:467` — `suggested package are not in renv prod even from vignettes` (with `document = TRUE`)

A fourth grepl in the same file (line 371, on `pkg_local_renv` which is already a `names(...)` vector) is correct and untouched.

## Test plan

- [x] Pre-fix on baseline: `[ FAIL 3 | WARN 0 | SKIP 1 | PASS 63 ]` for `test_file("test-renv_create.R")`
- [x] Post-fix: `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 61 ]`
- [x] `devtools::test()` full suite: `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 392 ]`
- [x] R CMD check unaffected (file is `skip_on_cran()`)

Independent of #136 — both branches diverge from main and don't touch each other's files.